### PR TITLE
Fix jQuery object for Foundry V13

### DIFF
--- a/scripts/token-hud-controller.js
+++ b/scripts/token-hud-controller.js
@@ -52,7 +52,7 @@ export const prepTokenHUD = (hud, html, token) => {
          .click((event) => tokenButtonHandler(event, actor, token))
          .contextmenu((event) => tokenButtonHandler(event, actor, token));
 
-      html.find("div.right").append(artButton);
+      $(html).find("div.right").append(artButton);
    }
 };
 


### PR DESCRIPTION
Description:

This pull request resolves a TypeError: html.find is not a function error that occurs when using this module with Foundry VTT v11 and newer versions.

Cause:

In Foundry v11, the renderTokenHUD hook was updated to pass a standard HTMLElement object for its html parameter, whereas it previously passed a jQuery object. The existing code was calling the .find() method directly on this HTMLElement, which caused the error.

Changes:

    In scripts/token-hud-controller.js, the html object is now wrapped with jQuery() (i.e., $(html)) before the .find() method is called. This restores the expected functionality without any other changes to the module's logic.